### PR TITLE
fix - add "," to CORS_ORIGIN_WHITELIST

### DIFF
--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -183,7 +183,7 @@ CORS_ORIGIN_ALLOW_ALL = False
 # and have a url
 # localhost:3000/ React's default local port
 CORS_ORIGIN_WHITELIST = (
-    'localhost:8000'
+    'https://localhost:8000',
 )
 
 print("=" * 20)

--- a/backend/settings/production.py
+++ b/backend/settings/production.py
@@ -177,7 +177,7 @@ CORS_ORIGIN_ALLOW_ALL = False
 # and have a url
 # localhost:3000/ React's default local port
 CORS_ORIGIN_WHITELIST = (
-    'beermeanother.herokuapp.com'
+    'https://beermeanother.herokuapp.com'
 )
 
 # at the bottom of your file


### PR DESCRIPTION
Fix error below by adding "," to CORS_ORIGIN_WHITELIST.

`(corsheaders.E013) Origin '/' in CORS_ORIGIN_WHITELIST is missing scheme or netloc`